### PR TITLE
Explicitly use https in google jsapi URL

### DIFF
--- a/src/hoplon/google/jsapi/loader.cljs.hl
+++ b/src/hoplon/google/jsapi/loader.cljs.hl
@@ -1,7 +1,7 @@
 (ns hoplon.google.jsapi.loader)
 
 (defc  api-key nil)
-(defc= api-url (str "//www.google.com/jsapi?key=" api-key))
+(defc= api-url (str "https://www.google.com/jsapi?key=" api-key))
 
 (defn queued [load-fn]
   (let [callbacks (atom [])


### PR DESCRIPTION
The context behind this PR is that I'm working on securing a Hoplon app by implementing a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) and I'd like to be able to specify in the CSP that `https://www.google.com` is a trusted source. [Mozilla Observatory](https://observatory.mozilla.org) will dock you points for loading resources over http.

I don't think there is any reason not to use https, even if the Hoplon app is being served over http.